### PR TITLE
atualização da URL do sagres UEFS

### DIFF
--- a/src/main/kotlin/com/forcetower/sagres/Constants.kt
+++ b/src/main/kotlin/com/forcetower/sagres/Constants.kt
@@ -36,13 +36,13 @@ class Constants(private val institution: String) {
          */
         private val SAGRES_SERVER_CONSTANTS = mapOf(
             "UEFS" to mapOf(
-                "BASE_URL" to "http://academico2.uefs.br/Portal",
+                "BASE_URL" to "http://academico.uefs.br/PortalSagres",
                 "LOGIN_VIEW_STATE" to "/wEPDwULLTE1ODU0NDkxODMPZBYCZg9kFgQCAQ9kFhACBA8WAh4EaHJlZgU9fi9BcHBfVGhlbWVzL05ld1RoZW1lL0FjZXNzb0V4dGVybm8uY3NzP2ZwPTYzNzAyNzc1MTk0MDAwMDAwMGQCBQ8WAh8ABTx+L0FwcF9UaGVtZXMvTmV3VGhlbWUvY2FwdGNoYS1oYWNrLmNzcz9mcD02MzcyMTMzNTQzOTYzNDg4NDdkAgYPFgIfAAU4fi9BcHBfVGhlbWVzL05ld1RoZW1lL0NvbnRldWRvLmNzcz9mcD02MzcwMjc3NTE5NDAwMDAwMDBkAgcPFgIfAAU5fi9BcHBfVGhlbWVzL05ld1RoZW1lL0VzdHJ1dHVyYS5jc3M/ZnA9NjM3MDI3NzUxOTQwMDAwMDAwZAIIDxYCHwAFOX4vQXBwX1RoZW1lcy9OZXdUaGVtZS9NZW5zYWdlbnMuY3NzP2ZwPTYzNzAyNzc1MTkwMDAwMDAwMGQCCQ8WAh8ABTZ+L0FwcF9UaGVtZXMvTmV3VGhlbWUvUG9wVXBzLmNzcz9mcD02MzcwMjc3NTE5MDAwMDAwMDBkAgoPFgIfAAU7fi9BcHBfVGhlbWVzL05ld1RoZW1lL3NvY2lhbC1oYWNrLmNzcz9mcD02MzcyMDI5ODg3NjU2OTg5NTdkAgsPFgIfAAVYL1BvcnRhbC9SZXNvdXJjZXMvU3R5bGVzL0FwcF9UaGVtZXMvTmV3VGhlbWUvTmV3VGhlbWUwMS9lc3RpbG8uY3NzP2ZwPTYzNjEwNTgyNjY0MDAwMDAwMGQCAw9kFgQCBw8PFgQeBFRleHQFDVNhZ3JlcyBQb3J0YWweB1Zpc2libGVoZGQCCw9kFgYCAQ8PFgIfAmhkZAIDDzwrAAoBAA8WAh4NUmVtZW1iZXJNZVNldGhkZAIFD2QWAgICD2QWAgIBDxYCHgtfIUl0ZW1Db3VudGZkZEQ9dOxjZzHs804b7zNS9kZWDDqS",
                 "LOGIN_VW_STT_GEN" to "BB137B96",
                 "LOGIN_VIEW_VALID" to "/wEdAAQ311wKHGQUWoLwp7PBHoaoM4nqN81slLG8uEFL8sVLUjoauXZ8QTl2nEJmPx53FYhjUq3W1Gjeb7bKHHg4dlobTvKU+hsWpu5LuPm5L8dsMwBIjEY=",
                 "REQUIRES_CAPTCHA" to "true",
                 "CAPTCHA_SITE_KEY" to "6Lc5M-UUAAAAAOFIqIdUEP2BeaqFi3f-71HscRlB",
-                "CAPTCHA_BASE" to "http://academico2.uefs.br"
+                "CAPTCHA_BASE" to "http://academico.uefs.br"
             ),
             "UESC" to mapOf(
                 "BASE_URL" to "http://www.prograd.uesc.br/PortalSagres",


### PR DESCRIPTION
a URL antiga padrão do sagres era _academico2.uefs.br/Portal_ mas agora é _academico.uefs.br/PortalSagres_, fiz essa alteração na arquivo de constantes, acredito que somente isso já fará o app voltar a funcionar